### PR TITLE
Fixed link to Heroku demo

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,7 +49,7 @@ Some example code::
                             shadow_trees=True)
     db.run(port=8050)
 
-The result can be viewed on `this dashboard deployed to heroku <titanicexplainer.herokuapp.com>`_
+The result can be viewed on `this dashboard deployed to heroku <http://titanicexplainer.herokuapp.com>`_
 
 
 


### PR DESCRIPTION
Seemed like the docs domain was being prepended to the heroku link. Sorry didn't look into the other sphinx errors