### PR TITLE
DOC: add conda-forge badge and pypi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/oegedijk/explainerdashboard/explainerdashboard/master?style=plastic)
 ![https://pypi.python.org/pypi/explainerdashboard/](https://img.shields.io/pypi/v/explainerdashboard.svg)
-![https://anaconda.org/conda-forge/explainerdashboard/badges/version.svg](https://anaconda.org/conda-forge/explainerdashboard/)
+![https://anaconda.org/conda-forge/explainerdashboard/](https://anaconda.org/conda-forge/explainerdashboard/badges/version.svg)
 [![codecov](https://codecov.io/gh/oegedijk/explainerdashboard/branch/master/graph/badge.svg?token=0XU6HNEGBK)](undefined)
 
 # explainerdashboard

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/oegedijk/explainerdashboard/explainerdashboard/master?style=plastic)
 ![https://pypi.python.org/pypi/explainerdashboard/](https://img.shields.io/pypi/v/explainerdashboard.svg)
-![https://anaconda.org/conda-forge/explainerdashboard](https://img.shields.io/conda/dn/conda-forge/explainerdashboard.svg)
+![https://anaconda.org/conda-forge/explainerdashboard/badges/version.svg](https://anaconda.org/conda-forge/explainerdashboard/)
 [![codecov](https://codecov.io/gh/oegedijk/explainerdashboard/branch/master/graph/badge.svg?token=0XU6HNEGBK)](undefined)
 
 # explainerdashboard
@@ -30,6 +30,10 @@ to the modular design of the library).
 You can install the package through pip:
 
 `pip install explainerdashboard`
+
+or conda-forge:
+
+`conda install -c conda-forge explainerdashboard`
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/oegedijk/explainerdashboard/explainerdashboard/master?style=plastic)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/oegedijk/explainerdashboard)
+![https://pypi.python.org/pypi/explainerdashboard/](https://img.shields.io/pypi/v/explainerdashboard.svg)
+![https://anaconda.org/conda-forge/explainerdashboard](https://img.shields.io/conda/dn/conda-forge/explainerdashboard.svg)
 [![codecov](https://codecov.io/gh/oegedijk/explainerdashboard/branch/master/graph/badge.svg?token=0XU6HNEGBK)](undefined)
 
 # explainerdashboard


### PR DESCRIPTION
Closes #9 

Added a conda-forge badge and added install instructions. Switched up the GitHub release badge for the pypi badge as this is where most people will download