### PR TITLE
Dispatching the ExplainerHub app to /{self.base_route}/index

### DIFF
--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -939,7 +939,7 @@ class ExplainerHub:
     add and delete users.
         
     """
-    __reserved_names = {'login', 'logout', 'admin'}
+    __reserved_names = {'login', 'logout', 'admin', 'index', 'hub'}
 
     def __init__(self, dashboards:List[ExplainerDashboard], title:str="ExplainerHub", 
                     description:str=None, masonry:bool=False, n_dashboard_cols:int=3, 
@@ -1341,7 +1341,8 @@ class ExplainerHub:
                 dashboard_name = f"dashboard{i+1}"
             else:
                 dashboard_name = dashboard.name
-
+            if dashboard_name in self.__reserved_names:
+                raise ValueError(f"ERROR! dashboard .name should not be in {self.__reserved_names}, but found '{dashboard_name}'!")
             update_params = dict(
                 server=self.app, 
                 name=dashboard_name, 

--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -1076,8 +1076,8 @@ class ExplainerHub:
                     self._protect_dashviews(dashboard.app, username=self.get_dashboard_users(dashboard.name))
         if not self.no_index:
             if index_to_base_route:
-                self.hub_base_url = f"/{self.base_route}/"
-                self.index_route = f"/{self.base_route}/index"
+                self.hub_base_url = f"/{self.base_route}/index/"
+                self.index_route = f"/{self.base_route}/hub/"
             else:
                 self.hub_base_url = "/index/"
                 self.index_route =  "/"

--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -1743,7 +1743,7 @@ class ExplainerHub:
         else:
             index_page = dash.Dash(__name__, 
                                 server=self.app, 
-                                url_base_pathname="/index/",
+                                url_base_pathname=f"/{self.base_route}/",
                                 external_stylesheets=[self.bootstrap] if self.bootstrap is not None else None)
             index_page.title = self.title
 
@@ -1770,7 +1770,7 @@ class ExplainerHub:
         <body class="d-flex flex-column min-vh-100">
             <div class="container{'-fluid' if self.fluid else ''}">
             <nav class="navbar navbar-expand-lg navbar-light bg-light">
-                <a class="navbar-brand" href="/">{self.title}</a>
+                <a class="navbar-brand" href="/{self.base_route}/hub">{self.title}</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
@@ -1787,7 +1787,7 @@ class ExplainerHub:
                             </div>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="/logout">Logout</a>
+                            <a class="nav-link" href="/{self.base_route}/logout">Logout</a>
                         </li>
                     </ul>
                 </div>
@@ -1814,10 +1814,10 @@ class ExplainerHub:
             app (flask.Flask): flask app to add routes to.
         """
         if self.users and not self.dbs_open_by_default:
-            @app.route("/")
+            @app.route(f"/{self.base_route}/hub/")
             @login_required
             def index_route():
-                return self._hub_page("/index")
+                return self._hub_page(f"/{self.base_route}/")
             
             def dashboard_route(dashboard):
                 def inner():
@@ -1828,9 +1828,9 @@ class ExplainerHub:
             for dashboard in self.dashboards:
                 app.route(f"/{self.base_route}/_{dashboard.name}")(login_required(dashboard_route(dashboard)))
         else:
-            @app.route("/")
+            @app.route(f"/{self.base_route}/hub/")
             def index_route():
-                return self._hub_page("/index")
+                return self._hub_page(f"/{self.base_route}/")
             
             def dashboard_route(dashboard):
                 def inner():
@@ -1896,7 +1896,7 @@ class ExplainerHub:
         """
         if port is None:
             port = self.port
-        print(f"Starting ExplainerHub on http://{get_local_ip_adress()}:{port}", flush=True)
+        print(f"Starting ExplainerHub on http://{get_local_ip_adress()}:{port}/{self.base_route}/hub", flush=True)
         if use_waitress:
             import waitress
             waitress.serve(self.app, host=host, port=port, **kwargs)  

--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -1787,7 +1787,7 @@ class ExplainerHub:
                             </div>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="/{self.base_route}/logout">Logout</a>
+                            <a class="nav-link" href="/logout">Logout</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
The current default base url path for Explainer path is hardcoded as "/index/". This PR changes this to /{self.base_route}/.
It also removes the routing of index to the "/" and changes that to {self.base_route}/index.

This is a rather quick implementation of the idea mentioned in  #130 
