### PR TITLE
hub: option to configure static route in base route

### DIFF
--- a/explainerdashboard/dashboard_components/shap_components.py
+++ b/explainerdashboard/dashboard_components/shap_components.py
@@ -326,7 +326,7 @@ class ShapDependenceComponent(ExplainerComponent):
                                 value=self.col)
                         ], md=3), self.hide_col),
                     make_hideable(dbc.Col([
-                            html.Label('Color feature:', id='shap-dependence-color-col-label-'+self.name),
+                            dbc.Label('Color feature:', id='shap-dependence-color-col-label-'+self.name),
                             dbc.Tooltip("Select feature to color the scatter markers by. This "
                                         "allows you to see interactions between various features in the graph.", 
                                         target='shap-dependence-color-col-label-'+self.name),


### PR DESCRIPTION
While deploying the ExplainerHub, I have no access to `/static` - so I added an option to set [`static_url_path`](https://flask.palletsprojects.com/en/2.1.x/api/#flask.Flask.static_url_path) similar to the `index_to_base_route` option.

This might be handy for others as well, so adding it into a PR.