### PR TITLE
Expose Dash routes_pathname_prefix and request requests_pathname_prefix

### DIFF
--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -366,6 +366,8 @@ class ExplainerDashboard:
                  external_stylesheets:List[str]=None,
                  server:bool=True,
                  url_base_pathname:str=None,
+                 routes_pathname_prefix:str=None,
+                 requests_pathname_prefix:str=None,
                  responsive:bool=True,
                  logins:List[List[str]]=None,
                  port:int=8050,
@@ -933,6 +935,8 @@ class ExplainerDashboard:
                             external_stylesheets=self.external_stylesheets, 
                             assets_ignore=assets_ignore,
                             url_base_pathname=self.url_base_pathname,
+                            routes_pathname_prefix=self.routes_pathname_prefix,
+                            requests_pathname_prefix=self.requests_pathname_prefix,
                             meta_tags=meta_tags)
         elif self.mode in ['inline', 'jupyterlab', 'external']:
             app = JupyterDash(__name__,

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ A deployed example can be found at http://titanicexplainer.herokuapp.com
         "Intended Audience :: Education",
         "Topic :: Scientific/Engineering :: Artificial Intelligence"],
     install_requires=requirements,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     entry_points={
         'console_scripts': [
             'explainerdashboard = explainerdashboard.cli:explainerdashboard_cli',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ A deployed example can be found at http://titanicexplainer.herokuapp.com
         "Intended Audience :: Education",
         "Topic :: Scientific/Engineering :: Artificial Intelligence"],
     install_requires=requirements,
-    python_requires='>=3.8',
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'explainerdashboard = explainerdashboard.cli:explainerdashboard_cli',


### PR DESCRIPTION
This is required to fix situations such as when ExplainerDashboard is running on JupyterHub behind a proxy. More precisely, asset paths  get broken if routes and requests are not specified differently. 

Similar to here: https://renkulab.io/projects/tasko.olevski/dash-example/files/blob/app.py

It was tested while trying to enable it to run on SageMaker Studio and it works.