### PR TITLE
fix: switch showticklabels=False to displaying transparent ticks

### DIFF
--- a/explainerdashboard/explainer_plots.py
+++ b/explainerdashboard/explainer_plots.py
@@ -1552,7 +1552,8 @@ def plotly_shap_scatter_plot(X, shap_values_df, display_columns=None, title="Sha
                               opacity=0.3,
                               colorbar=dict(
                                 title="feature value <br> (red is high)", 
-                                showticklabels=False),
+                                tickfont=dict(color="rgba(0, 0, 0, 0)"),
+                                ),
                             ),
                             name=col,
                             showlegend=False,


### PR DESCRIPTION
Fixes the issue where the detailed option of the shap summary plot does not display.

A fix for @schwanne and @woochan-jang's problems in issue #236 