### PR TITLE
Convert the ascii arts to raw strings

### DIFF
--- a/explainerdashboard/cli.py
+++ b/explainerdashboard/cli.py
@@ -18,7 +18,7 @@ from explainerdashboard.explainers import BaseExplainer
 from explainerdashboard.dashboards import ExplainerDashboard
 
 
-explainer_ascii = """
+explainer_ascii = r"""
 
  _____ ___ __| |__ _(_)_ _  ___ _ _ __| |__ _ __| |_ | |__  ___  __ _ _ _ __| |
 / -_) \ / '_ \ / _` | | ' \/ -_) '_/ _` / _` (_-< ' \| '_ \/ _ \/ _` | '_/ _` |
@@ -27,7 +27,7 @@ explainer_ascii = """
 
 """
 
-hub_ascii = """
+hub_ascii = r"""
 
                _      _              _        _    
   _____ ___ __| |__ _(_)_ _  ___ _ _| |_ _  _| |__ 


### PR DESCRIPTION
## PR Summary
This small PR converts the ascii arts to raw strings in order to solve the following warnings which you can find in the [CI logs](https://github.com/oegedijk/explainerdashboard/actions/runs/15400817814/job/43332722781#step:9:249):
```python
/home/runner/work/explainerdashboard/explainerdashboard/explainerdashboard/cli.py:21: DeprecationWarning: invalid escape sequence '\ '
/home/runner/work/explainerdashboard/explainerdashboard/explainerdashboard/cli.py:30: DeprecationWarning: invalid escape sequence '\ '
```