### PR TITLE
Fix: Replace deprecated app.run_server with app.run  (#313)

### DIFF
--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -1275,7 +1275,7 @@ class ExplainerDashboard:
 
                 serve(app.server, host=host, port=port)
             else:
-                app.run_server(port=port, host=host, **kwargs)
+                app.run(port=port, host=host, **kwargs)
         else:
             if self.mode == "dash":
                 print(


### PR DESCRIPTION
Dash 2.0+ deprecated `app.run_server()` in favor of `app.run()`, which raises an `ObsoleteAttributeException` when running:

```python
ExplainerDashboard(...).run()
```

This PR updates line **1278** of `explainerdashboard/dashboards.py` to use `app.run()` instead.

Fixes :  #313