### PR TITLE
Add try-except to support both Dash >=2.0 and <2.0

### DIFF
--- a/explainerdashboard/dashboards.py
+++ b/explainerdashboard/dashboards.py
@@ -1272,10 +1272,12 @@ class ExplainerDashboard:
             )
             if use_waitress:
                 from waitress import serve
-
                 serve(app.server, host=host, port=port)
             else:
-                app.run_server(port=port, host=host, **kwargs)
+                try:
+                    app.run(port=port, host=host, **kwargs)
+                except AttributeError:
+                    app.run_server(port=port, host=host, **kwargs)
         else:
             if self.mode == "dash":
                 print(


### PR DESCRIPTION
- Included try-except block to handle compatibility between app.run() (Dash ≥ 2.0) and app.run_server() (older versions).
- Helps avoid AttributeError during launch.

Note: There seems to be a red-line/error in the block I couldn’t pinpoint the cause—please have a look.