### PR TITLE
Improve pipeline feature naming and categorical grouping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ db = ExplainerDashboard(explainer,
 db.run(port=8050)
 ```
 
+If you are passing an sklearn/imblearn `Pipeline`, you can also clean up transformed
+feature names and let the explainer infer onehot groups automatically:
+
+```python
+explainer = ClassifierExplainer(
+    pipeline_model, X_test, y_test,
+    strip_pipeline_prefix=True,      # e.g. "num__Age" -> "Age"
+    feature_name_fn=None,            # optional custom rename function
+    auto_detect_pipeline_cats=True,  # infer cats from transformed pipeline output
+)
+```
+
 For a regression model you can also pass the units of the target variable (e.g.
 dollars):
 
@@ -183,6 +195,10 @@ explainer = RegressionExplainer(model, X_test, y_test,
 
 ExplainerDashboard(explainer).run()
 ```
+
+For pipeline-based models with post-processing/scaling, grouped categorical
+features passed through `cats` are now accepted as long as encoded columns are
+binary-like (not strictly only `0/1`).
 
 `y_test` is actually optional, although some parts of the dashboard like performance
 metrics will obviously not be available: `ExplainerDashboard(ClassifierExplainer(model, X_test)).run()`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,15 @@
 - Add CatBoost regression tests for classifier/regression `pdp_df(...)` with `X_row` containing missing categorical values.
 - Add hub regression test for integrated hub yaml serialization to verify `pickle_type` is preserved and explainer artifacts are written.
 - Add regression tests for issue #294 covering multiclass logodds consistency across prediction table, contributions, PDP highlight predictions, and XGBoost decision-path summaries.
+- Add pipeline tests for transformed feature-name cleanup (`strip_pipeline_prefix`, `feature_name_fn`) and pipeline categorical grouping autodetection.
+- Add explainer-method unit tests for binary-like onehot detection, transformed feature-name deduping, inferred pipeline cats, and pipeline extraction warning text.
+
+### Improvements
+- Add pipeline feature-name cleanup options: `strip_pipeline_prefix=True` and `feature_name_fn=...` for sklearn/imblearn pipeline transformed output columns.
+- Add optional `auto_detect_pipeline_cats=True` to infer onehot groups from transformed pipeline columns when `cats` is not provided.
+- Preserve input index in transformed pipeline dataframes produced during pipeline extraction.
+- Improve pipeline extraction warning guidance and include concrete checks (`get_feature_names_out`, transform compatibility on `X`/`X_background`).
+- Relax onehot grouping validation to also accept binary-like scaled onehot columns (not only strict `0/1`) when parsing `cats`.
 
 ### CI
 - Update `explainerdashboard` GitHub Actions workflow to run a weekly scheduled full test suite (`pytest`) to detect dependency breakages earlier.

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [M][Explainers][#198/#340] LightGBM string categorical handling across SHAP/plots.
 - [S][Hub][#146/#342] hub.to_yaml integrate_dashboard_yamls honors pickle_type and dumps integrated explainer artifacts.
 - [M][Explainers][#294] align/explain multiclass logodds between Contributions Plot and Prediction Box (+ PDP highlight and XGBoost decision path wording alignment).
+- [M][Explainers/Methods/Docs][#213] improve sklearn/imblearn pipeline support: feature-name cleanup (`strip_pipeline_prefix`, `feature_name_fn`), auto-detect onehot groups (`auto_detect_pipeline_cats`), accept binary-like scaled onehot columns in `cats`, preserve transformed index, add warnings/docs/tests.
 
 **Now**
 - [M][Explainers][#118] add LightGBM tree visualization support (dtreeviz).

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -3,23 +3,23 @@ Deployment
 
 When deploying your dashboard it is better not to use the built-in flask
 development server but use a more robust production server like ``gunicorn`` or ``waitress``.
-Probably `gunicorn <https://gunicorn.org/>`_ is a bit more fully featured and 
+Probably `gunicorn <https://gunicorn.org/>`_ is a bit more fully featured and
 faster but only works on unix/linux/osx, whereas
-`waitress <https://docs.pylonsproject.org/projects/waitress/en/stable/>`_ also works 
-on Windows and has very minimal dependencies. 
+`waitress <https://docs.pylonsproject.org/projects/waitress/en/stable/>`_ also works
+on Windows and has very minimal dependencies.
 
-Install with either ``pip install gunicorn`` or ``pip install waitress``. 
+Install with either ``pip install gunicorn`` or ``pip install waitress``.
 
 Storing explainer and running default dashboard with gunicorn
 =============================================================
 
-Before you start a dashboard with gunicorn you need to store both the explainer 
+Before you start a dashboard with gunicorn you need to store both the explainer
 instance and and a configuration for the dashboard::
 
     from explainerdashboard import ClassifierExplainer, ExplainerDashboard
 
     explainer = ClassifierExplainer(model, X, y)
-    db = ExplainerDashboard(explainer, title="Cool Title", shap_interaction=False) 
+    db = ExplainerDashboard(explainer, title="Cool Title", shap_interaction=False)
     db.to_yaml("dashboard.yaml", explainerfile="explainer.joblib", dump_explainer=True)
 
 Now you re-load your dashboard and expose a flask server as ``app`` in ``dashboard.py``::
@@ -27,7 +27,7 @@ Now you re-load your dashboard and expose a flask server as ``app`` in ``dashboa
     from explainerdashboard import ExplainerDashboard
 
     db = ExplainerDashboard.from_config("dashboard.yaml")
-    app = db.flask_server() 
+    app = db.flask_server()
 
 
 .. highlight:: bash
@@ -36,13 +36,13 @@ If you named the file above ``dashboard.py``, you can now start the gunicorn ser
 
     $ gunicorn dashboard:app
 
-If you want to run the server server with for example three workers, binding to 
+If you want to run the server server with for example three workers, binding to
 port ``8050`` you launch gunicorn with::
 
     $ gunicorn -w 3 -b localhost:8050 dashboard:app
 
-If you now point your browser to ``http://localhost:8050`` you should see your dashboard. 
-Next step is finding a nice url in your organization's domain, and forwarding it 
+If you now point your browser to ``http://localhost:8050`` you should see your dashboard.
+Next step is finding a nice url in your organization's domain, and forwarding it
 to your dashboard server.
 
 With waitress you would call::
@@ -70,11 +70,11 @@ You need to pass the Flask ``server`` instance and the ``url_base_pathname`` to 
 under ``db.app.index``::
 
     from flask import Flask
-    
+
     app = Flask(__name__)
 
     [...]
-    
+
     db = ExplainerDashboard(explainer, server=app, url_base_pathname="/dashboard/")
 
     @app.route('/dashboard')
@@ -82,7 +82,7 @@ under ``db.app.index``::
         return db.app.index()
 
 
-.. highlight:: bash 
+.. highlight:: bash
 
 Now you can start the dashboard by::
 
@@ -95,12 +95,12 @@ Deploying to heroku
 ===================
 
 In case you would like to deploy to `heroku <www.heroku.com>`_ (which is normally
-the simplest option for dash apps, see 
-`dash instructions here <https://dash.plotly.com/deployment>`_). The demonstration 
+the simplest option for dash apps, see
+`dash instructions here <https://dash.plotly.com/deployment>`_). The demonstration
 dashboard is also hosted on heroku at `titanicexplainer.herokuapp.com <http://titanicexplainer.herokuapp.com>`_.
 
-In order to deploy the heroku there are a few things to keep in mind. First of 
-all you need to add ``explainerdashboard`` and ``gunicorn`` to 
+In order to deploy the heroku there are a few things to keep in mind. First of
+all you need to add ``explainerdashboard`` and ``gunicorn`` to
 ``requirements.txt`` (pinning is recommended to force a new build of your environment
 whenever you upgrade versions)::
 
@@ -112,8 +112,8 @@ your explainer in ``runtime.txt``::
 
     python-3.8.6
 
-(supported versions as of this writing are ``python-3.9.0``, ``python-3.8.6``, 
-``python-3.7.9`` and ``python-3.6.12``, but check the 
+(supported versions as of this writing are ``python-3.9.0``, ``python-3.8.6``,
+``python-3.7.9`` and ``python-3.6.12``, but check the
 `heroku documentation <https://devcenter.heroku.com/articles/python-support#supported-runtimes>`_
 for the latest)
 
@@ -126,10 +126,10 @@ And you need to tell heroku how to start your server in ``Procfile``::
 Graphviz buildpack
 ------------------
 
-If you want to visualize individual trees inside your ``RandomForest`` or ``xgboost`` 
+If you want to visualize individual trees inside your ``RandomForest`` or ``xgboost``
 model using the ``dtreeviz`` package you will
 need to make sure that ``graphviz`` is installed on your ``heroku`` dyno by
-adding the following buildstack (as well as the ``python`` buildpack): 
+adding the following buildstack (as well as the ``python`` buildpack):
 ``https://github.com/weibeld/heroku-buildpack-graphviz.git``
 
 (you can add buildpacks through the "settings" page of your heroku project)
@@ -150,10 +150,16 @@ E.g. **generate_dashboard.py**::
     X_train, y_train, X_test, y_test = titanic_survive()
     model = RandomForestClassifier(n_estimators=50, max_depth=5).fit(X_train, y_train)
 
-    explainer = ClassifierExplainer(model, X_test, y_test, 
+    explainer = ClassifierExplainer(model, X_test, y_test,
                                     cats=["Sex", 'Deck', 'Embarked'],
                                     labels=['Not Survived', 'Survived'],
                                     descriptions=feature_descriptions)
+
+    # For sklearn/imblearn pipeline models you can alternatively use:
+    # explainer = ClassifierExplainer(
+    #     pipeline_model, X_test, y_test,
+    #     strip_pipeline_prefix=True,
+    #     auto_detect_pipeline_cats=True)
 
     db = ExplainerDashboard(explainer)
     db.to_yaml("dashboard.yaml", explainerfile="explainer.joblib", dump_explainer=True)
@@ -193,45 +199,45 @@ Reducing memory usage
 
 If you deploy the dashboard with a large dataset with a large number of rows (``n``)
 and a large number of columns (``m``),
-it can use up quite a bit of memory: the dataset itself, shap values, 
+it can use up quite a bit of memory: the dataset itself, shap values,
 shap interaction values and any other calculated properties are alle kept in
 memory in order to make the dashboard responsive. You can check the (approximate)
 memory usage with ``explainer.memory_usage()``. In order to reduce the memory
 footprint there are a number of things you can do:
 
 1. Not including shap interaction tab.
-    Shap interaction values are shape ``n*m*m``, so can take a subtantial amount 
-    of memory, especially if you have a significant amount of columns ``m``. 
-2. Setting a lower precision. 
+    Shap interaction values are shape ``n*m*m``, so can take a subtantial amount
+    of memory, especially if you have a significant amount of columns ``m``.
+2. Setting a lower precision.
     By default shap values are stored as ``'float64'``,
     but you can store them as ``'float32'`` instead and save half the space:
-    ```ClassifierExplainer(model, X_test, y_test, precision='float32')```. You 
+    ```ClassifierExplainer(model, X_test, y_test, precision='float32')```. You
     can also set a lower precision on your ``X_test`` dataset yourself ofcourse.
 3. Drop non-positive class shap values.
     For multi class classifiers, by default ``ClassifierExplainer`` calculates
     shap values for all classes. If you are only interested in a single class
     you can drop the other shap values with ``explainer.keep_shap_pos_label_only(pos_label)``
-4. Storing row data externally and loading on the fly. 
+4. Storing row data externally and loading on the fly.
     You can for example only store a subset of ``10.000`` rows in
     the ``explainer`` itself (enough to generate representative importance and dependence plots),
-    and store the rest of your millions of rows of input data in an external file 
+    and store the rest of your millions of rows of input data in an external file
     or database that get loaded one by one with the following functions:
 
-    - with ``explainer.set_X_row_func()`` you can set a function that takes 
+    - with ``explainer.set_X_row_func()`` you can set a function that takes
       an `index` as argument and returns a single row dataframe with model
       compatible input data for that index. This function can include a query
-      to a database or fileread. 
-    - with ``explainer.set_y_func()`` you can set a function that takes 
+      to a database or fileread.
+    - with ``explainer.set_y_func()`` you can set a function that takes
       and `index` as argument and returns the observed outcome ``y`` for
       that index.
-    - with ``explainer.set_index_list_func()`` you can set a function 
+    - with ``explainer.set_index_list_func()`` you can set a function
       that returns a list of available indexes that can be queried.
-    
-    If the number of indexes is too long to fit in a dropdown you can pass 
+
+    If the number of indexes is too long to fit in a dropdown you can pass
     ``index_dropdown=False`` which turns the dropdowns into free text fields.
-    Instead of an ``index_list_func`` you can also set an 
+    Instead of an ``index_list_func`` you can also set an
     ``explainer.set_index_check_func(func)`` which should return a bool whether
-    the ``index`` exists or not. 
+    the ``index`` exists or not.
 
     Important: these function can be called multiple times by multiple independent
     components, so probably best to implement some kind of caching functionality.
@@ -242,22 +248,22 @@ footprint there are a number of things you can do:
 Setting logins and password
 ===========================
 
-``ExplainerDashboard`` supports `dash basic auth functionality <https://dash.plotly.com/authentication>`_. 
+``ExplainerDashboard`` supports `dash basic auth functionality <https://dash.plotly.com/authentication>`_.
 ``ExplainerHub`` uses ``flask_simple_login`` for its user authentication.
 
-You can simply add a list of logins to the ``ExplainerDashboard`` to force a login 
+You can simply add a list of logins to the ``ExplainerDashboard`` to force a login
 and prevent random users from accessing the details of your model dashboard::
 
     ExplainerDashboard(explainer, logins=[['login1', 'password1'], ['login2', 'password2']]).run()
 
-Whereas :ref:`ExplainerHub<ExplainerHub>` has somewhat more intricate user management 
-using ``FlaskLogin``, but the basic syntax is the same. See the 
+Whereas :ref:`ExplainerHub<ExplainerHub>` has somewhat more intricate user management
+using ``FlaskLogin``, but the basic syntax is the same. See the
 :ref:`ExplainerHub documetation<ExplainerHub>` for more details::
 
     hub = ExplainerHub([db1, db2], logins=[['login1', 'password1'], ['login2', 'password2']])
 
-Make sure not to check these login/password pairs into version control though, 
-but store them somewhere safe! ``ExplainerHub`` stores passwords into a hashed 
+Make sure not to check these login/password pairs into version control though,
+but store them somewhere safe! ``ExplainerHub`` stores passwords into a hashed
 format by default.
 
 
@@ -266,20 +272,20 @@ Automatically restart gunicorn server upon changes
 
 We can use the ``explainerdashboard`` CLI tools to automatically rebuild our
 explainer whenever there is a change to the underlying
-model, dataset or explainer configuration. And we we can use ``kill -HUP gunicorn.pid`` 
-to force the gunicorn to restart and reload whenever a new ``explainer.joblib`` 
-is generated or the dashboard configuration ``dashboard.yaml`` changes. These two 
-processes together ensure that the dashboard automatically updates whenever there 
+model, dataset or explainer configuration. And we we can use ``kill -HUP gunicorn.pid``
+to force the gunicorn to restart and reload whenever a new ``explainer.joblib``
+is generated or the dashboard configuration ``dashboard.yaml`` changes. These two
+processes together ensure that the dashboard automatically updates whenever there
 are underlying changes.
 
-First we store the explainer config in ``explainer.yaml`` and the dashboard 
+First we store the explainer config in ``explainer.yaml`` and the dashboard
 config in ``dashboard.yaml``. We also indicate which modelfiles and datafiles the
-explainer depends on, and which columns in the datafile should be used as 
+explainer depends on, and which columns in the datafile should be used as
 a target and which as index::
 
     explainer = ClassifierExplainer(model, X, y, labels=['Not Survived', 'Survived'])
     explainer.dump("explainer.joblib")
-    explainer.to_yaml("explainer.yaml", 
+    explainer.to_yaml("explainer.yaml",
                     modelfile="model.pkl",
                     datafile="data.csv",
                     index_col="Name",
@@ -300,12 +306,12 @@ directly from the config file::
 
 .. highlight:: bash
 
-Now we would like to rebuild the ``explainer.joblib`` file whenever there is a 
-change to ``model.pkl``, ``data.csv`` or ``explainer.yaml`` by running 
-``explainerdashboard build``. And we restart the ``gunicorn`` server whenever 
-there is a change in ``explainer.joblib`` or ``dashboard.yaml`` by killing 
-the gunicorn server with ``kill -HUP pid`` To do that we need to install 
-the python package ``watchdog`` (``pip install watchdog[watchmedo]``). This 
+Now we would like to rebuild the ``explainer.joblib`` file whenever there is a
+change to ``model.pkl``, ``data.csv`` or ``explainer.yaml`` by running
+``explainerdashboard build``. And we restart the ``gunicorn`` server whenever
+there is a change in ``explainer.joblib`` or ``dashboard.yaml`` by killing
+the gunicorn server with ``kill -HUP pid`` To do that we need to install
+the python package ``watchdog`` (``pip install watchdog[watchmedo]``). This
 package can keep track of filechanges and execute shell-scripts upon file changes.
 
 So we can start the gunicorn server and the two watchdog filechange trackers
@@ -321,17 +327,14 @@ from a shell script ``start_server.sh``::
 
     wait # wait till user hits ctrl-c to exit and kill all three processes
 
-Now we can simply run ``chmod +x start_server.sh`` and ``./start_server.sh`` to 
+Now we can simply run ``chmod +x start_server.sh`` and ``./start_server.sh`` to
 get our server up and running.
 
-Whenever we now make a change to either one of the source files 
+Whenever we now make a change to either one of the source files
 (``model.pkl``, ``data.csv`` or ``explainer.yaml``), this produces a fresh
 ``explainer.joblib``. And whenever there is a change to either ``explainer.joblib``
-or ``dashboard.yaml`` gunicorns restarts and rebuild the dashboard. 
+or ``dashboard.yaml`` gunicorns restarts and rebuild the dashboard.
 
-So you can keep an explainerdashboard running without interuption and simply 
-an updated ``model.pkl`` or a fresh dataset ``data.csv`` into the directory and 
-the dashboard will automatically update. 
-
-
-
+So you can keep an explainerdashboard running without interuption and simply
+an updated ``model.pkl`` or a fresh dataset ``data.csv`` into the directory and
+the dashboard will automatically update.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,16 +5,16 @@ Summary
 =======
 
 ``explainerdashboard`` is a library for quickly building interactive dashboards
-for analyzing and explaining the predictions and workings of 
+for analyzing and explaining the predictions and workings of
 (scikit-learn compatible) machine learning models, including
 xgboost, catboost and lightgbm. This makes your model transparant and explainable
-with just two lines of code. 
+with just two lines of code.
 
-It allows you to investigate SHAP values, permutation importances, 
+It allows you to investigate SHAP values, permutation importances,
 interaction effects, partial dependence plots, all kinds of performance plots,
-and even individual decision trees inside a random forest. With ``explainerdashboard`` any data 
-scientist can create an interactive explainable AI web app in minutes, 
-without having to know anything about web development or deployment. 
+and even individual decision trees inside a random forest. With ``explainerdashboard`` any data
+scientist can create an interactive explainable AI web app in minutes,
+without having to know anything about web development or deployment.
 
 You first construct an ``explainer`` object out of your model and the test data::
 
@@ -27,7 +27,7 @@ You then pass this ``explainer`` object to an ``ExplainerDashboard`` and run it:
 
 .. image:: screenshots/screenshot.*
 
-You can host multiple ExplainerDashboard in an ``ExplainerHub`` by passing in a 
+You can host multiple ExplainerDashboard in an ``ExplainerHub`` by passing in a
 list of dashboards::
 
     db1 = ExplainerDashboard(explainer1)
@@ -46,11 +46,11 @@ See :ref:`ExplainerHub documentation<ExplainerHub>`
 InlineExplainer
 ===============
 
-For viewing and customizing individual components or tabs directly inside your 
+For viewing and customizing individual components or tabs directly inside your
 notebook you use the ``InlineExplainer``::
 
     from explainerdashboard import InlineExplainer
-    
+
     InlineExplainer(explainer).shap.dependence()
     InlineExplainer(explainer).shap.dependence(hide_cats=True, hide_index=True, col="Fare")
     InlineExplainer(explainer).shap.overview()
@@ -68,7 +68,7 @@ to directly make plots inline in your notebook:
 A more extended example
 =======================
 
-Some example code, where we load some data, fit a model, construct an explainer, 
+Some example code, where we load some data, fit a model, construct an explainer,
 pass it on to an ``ExplainerDashboard`` and run the dashboard::
 
     from sklearn.ensemble import RandomForestClassifier
@@ -82,7 +82,7 @@ pass it on to an ``ExplainerDashboard`` and run the dashboard::
     model.fit(X_train, y_train)
 
     explainer = ClassifierExplainer(
-                    model, X_test, y_test, 
+                    model, X_test, y_test,
                     # optional:
                     cats=['Sex', 'Deck', 'Embarked'],
                     labels=['Not survived', 'Survived'])
@@ -93,11 +93,19 @@ pass it on to an ``ExplainerDashboard`` and run the dashboard::
                         decision_trees=False)
     db.run(port=8051)
 
+For sklearn/imblearn pipeline models, you can also enable pipeline-aware feature
+name cleanup and automatic categorical grouping::
+
+    explainer = ClassifierExplainer(
+        pipeline_model, X_test, y_test,
+        strip_pipeline_prefix=True,
+        auto_detect_pipeline_cats=True)
+
 Or, as a one-liner::
 
     ExplainerDashboard(
         ClassifierExplainer(
-            RandomForestClassifier().fit(X_train, y_train), 
+            RandomForestClassifier().fit(X_train, y_train),
             X_test, y_test
         )
     ).run()
@@ -114,7 +122,7 @@ Custom dashboards
 =================
 You can easily :ref:`remix and customize<CustomModelTab>` ``ExplainerComponent`` primitives into
 your own custom layouts for a dashboard that is specifically tailored to
-your own model and project. For example a dashboard with a single SHAP dependence 
+your own model and project. For example a dashboard with a single SHAP dependence
 component::
 
     from explainerdashboard.custom import *
@@ -131,14 +139,14 @@ component::
     ExplainerDashboard(explainer, CustomDashboard).run()
 
 
-A more elaborate example of  :ref:`a custom dashboard<CustomModelTab>` 
+A more elaborate example of  :ref:`a custom dashboard<CustomModelTab>`
 (example deployed `here <http://titanicexplainer.herokuapp.com/custom/>`_):
 
 .. image:: screenshots/custom_dashboard.*
 
 
-More examples of how to start dashboards for different types of models and with 
-different parameters can be found in the `dashboard_examples notebook <https://github.com/oegedijk/explainerdashboard/blob/master/notebooks/dashboard_examples.ipynb>`_ 
+More examples of how to start dashboards for different types of models and with
+different parameters can be found in the `dashboard_examples notebook <https://github.com/oegedijk/explainerdashboard/blob/master/notebooks/dashboard_examples.ipynb>`_
 in the github repo.
 
 For examples on how to interact with and get plots and dataframes out of the explainer

--- a/tests/test_explainer_methods.py
+++ b/tests/test_explainer_methods.py
@@ -1,0 +1,116 @@
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from explainerdashboard.explainer_methods import (
+    build_pipeline_extraction_warning,
+    get_transformed_X,
+    infer_cats_from_transformed_X,
+    is_binary_like_onehot_column,
+    rename_pipeline_columns,
+    split_pipeline,
+)
+
+
+def test_is_binary_like_onehot_column_accepts_strict_onehot_values():
+    series = pd.Series([0, 1, 0, 1, 0], dtype=float)
+    assert is_binary_like_onehot_column(series)
+
+
+def test_is_binary_like_onehot_column_accepts_scaled_binary_values():
+    series = pd.Series([-1.0, 0.5, -1.0, 0.5, -1.0], dtype=float)
+    assert is_binary_like_onehot_column(series)
+
+
+def test_is_binary_like_onehot_column_rejects_non_binary_values():
+    series = pd.Series([0.0, 0.5, 1.0, 0.5, 0.0], dtype=float)
+    assert not is_binary_like_onehot_column(series)
+
+
+def test_rename_pipeline_columns_strips_prefixes():
+    columns = ["num__age", "cat__city_A", "cat__city_B"]
+    renamed = rename_pipeline_columns(columns, strip_pipeline_prefix=True)
+    assert renamed == ["age", "city_A", "city_B"]
+
+
+def test_rename_pipeline_columns_uses_custom_function():
+    columns = ["num__age", "cat__city_A"]
+    renamed = rename_pipeline_columns(columns, feature_name_fn=lambda c: c.upper())
+    assert renamed == ["NUM__AGE", "CAT__CITY_A"]
+
+
+def test_rename_pipeline_columns_suffixes_duplicates():
+    columns = ["num__age", "cat__age"]
+    renamed = rename_pipeline_columns(columns, strip_pipeline_prefix=True, verbose=0)
+    assert renamed == ["age", "age__2"]
+
+
+def test_get_transformed_X_preserves_index():
+    X = pd.DataFrame(
+        {"age": [20, 21, 22, 23], "city": ["A", "B", "A", "C"]},
+        index=["row-1", "row-2", "row-3", "row-4"],
+    )
+    y = np.array([10, 11, 12, 13])
+    pipeline = Pipeline(
+        [
+            (
+                "preprocessor",
+                ColumnTransformer(
+                    [
+                        ("num", StandardScaler(), ["age"]),
+                        (
+                            "cat",
+                            OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                            ["city"],
+                        ),
+                    ],
+                    sparse_threshold=0,
+                ),
+            ),
+            ("model", LinearRegression()),
+        ]
+    ).fit(X, y)
+    transformer_pipeline, _ = split_pipeline(pipeline, verbose=0)
+    transformed_X = get_transformed_X(transformer_pipeline, X, verbose=0)
+
+    assert list(transformed_X.index) == list(X.index)
+
+
+def test_infer_cats_from_transformed_X_detects_onehot_groups():
+    X = pd.DataFrame({"age": [20, 21, 22, 23], "city": ["A", "B", "A", "C"]})
+    y = np.array([10, 11, 12, 13])
+    pipeline = Pipeline(
+        [
+            (
+                "preprocessor",
+                ColumnTransformer(
+                    [
+                        ("num", StandardScaler(), ["age"]),
+                        (
+                            "cat",
+                            OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                            ["city"],
+                        ),
+                    ],
+                    sparse_threshold=0,
+                ),
+            ),
+            ("model", LinearRegression()),
+        ]
+    ).fit(X, y)
+    transformer_pipeline, _ = split_pipeline(pipeline, verbose=0)
+    transformed_X = get_transformed_X(transformer_pipeline, X, verbose=0)
+
+    inferred = infer_cats_from_transformed_X(transformed_X, list(X.columns))
+
+    assert inferred == {"cat__city": ["cat__city_A", "cat__city_B", "cat__city_C"]}
+
+
+def test_build_pipeline_extraction_warning_has_actionable_guidance():
+    message = build_pipeline_extraction_warning(RuntimeError("boom"))
+    assert "set shap='kernel'" in message
+    assert "get_feature_names_out" in message
+    assert "Error: boom" in message

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,5 +1,17 @@
 import pandas as pd
 import numpy as np
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from explainerdashboard.explainer_methods import (
+    get_transformed_X,
+    parse_cats,
+    split_pipeline,
+)
+from explainerdashboard import RegressionExplainer
 
 
 def test_pipeline_columns_ranked_by_shap(classifier_pipeline_explainer):
@@ -125,3 +137,199 @@ def test_pipeline_kernel_pdp_df(classifier_pipeline_kernel_explainer):
     assert isinstance(
         classifier_pipeline_kernel_explainer.pdp_df("sex", index=0), pd.DataFrame
     )
+
+
+def test_get_transformed_X_strip_pipeline_prefix_removes_double_underscores():
+    X = pd.DataFrame(
+        {
+            "age": [20, 21, 22, 23, 24, 25],
+            "city": ["A", "B", "A", "C", "B", "A"],
+        }
+    )
+    y = np.array([0, 1, 0, 1, 0, 1])
+
+    preprocessor = ColumnTransformer(
+        [
+            ("num", StandardScaler(), ["age"]),
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                ["city"],
+            ),
+        ],
+        sparse_threshold=0,
+    )
+    pipeline = Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("model", LogisticRegression(max_iter=200)),
+        ]
+    ).fit(X, y)
+
+    transformer_pipeline, _ = split_pipeline(pipeline, verbose=0)
+    transformed_X = get_transformed_X(
+        transformer_pipeline, X, verbose=0, strip_pipeline_prefix=True
+    )
+
+    assert all("__" not in col for col in transformed_X.columns)
+    assert {"age", "city_A", "city_B", "city_C"}.issubset(set(transformed_X.columns))
+
+
+def test_parse_cats_accepts_scaled_binary_like_onehot_columns():
+    X = pd.DataFrame(
+        {
+            "age": [20, 21, 22, 23, 24, 25],
+            "city": ["A", "A", "A", "A", "B", "C"],
+        }
+    )
+    y = np.array([0, 1, 0, 1, 0, 1])
+
+    preprocessor = ColumnTransformer(
+        [
+            ("num", StandardScaler(), ["age"]),
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                ["city"],
+            ),
+        ],
+        sparse_threshold=0,
+    )
+    pipeline = Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("post_scale", StandardScaler()),
+            ("model", LogisticRegression(max_iter=200)),
+        ]
+    ).fit(X, y)
+
+    transformer_pipeline, _ = split_pipeline(pipeline, verbose=0)
+    transformed_X = get_transformed_X(transformer_pipeline, X, verbose=0)
+
+    onehot_cols, onehot_dict = parse_cats(transformed_X, ["cat__city"])
+
+    assert onehot_cols == ["cat__city"]
+    assert set(onehot_dict["cat__city"]) == {
+        "cat__city_A",
+        "cat__city_B",
+        "cat__city_C",
+    }
+
+
+def test_pipeline_feature_name_fn_passthrough_applies_to_explainer_columns():
+    X = pd.DataFrame(
+        {
+            "age": [20, 21, 22, 23, 24, 25],
+            "city": ["A", "B", "A", "C", "B", "A"],
+        }
+    )
+    y = pd.Series([10, 11, 12, 13, 14, 15])
+
+    preprocessor = ColumnTransformer(
+        [
+            ("num", StandardScaler(), ["age"]),
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                ["city"],
+            ),
+        ],
+        sparse_threshold=0,
+    )
+    pipeline = Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("model", LinearRegression()),
+        ]
+    ).fit(X, y)
+
+    explainer = RegressionExplainer(
+        pipeline,
+        X,
+        y,
+        feature_name_fn=lambda c: c.split("__", 1)[1] if "__" in c else c,
+    )
+
+    assert "num__age" not in explainer.columns
+    assert "age" in explainer.columns
+
+
+def test_pipeline_auto_detect_cats_groups_onehot_columns():
+    X = pd.DataFrame(
+        {
+            "age": [20, 21, 22, 23, 24, 25],
+            "city": ["A", "B", "A", "C", "B", "A"],
+        }
+    )
+    y = pd.Series([10, 11, 12, 13, 14, 15])
+
+    preprocessor = ColumnTransformer(
+        [
+            ("num", StandardScaler(), ["age"]),
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                ["city"],
+            ),
+        ],
+        sparse_threshold=0,
+    )
+    pipeline = Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("model", LinearRegression()),
+        ]
+    ).fit(X, y)
+
+    explainer = RegressionExplainer(
+        pipeline,
+        X,
+        y,
+        auto_detect_pipeline_cats=True,
+    )
+
+    assert "cat__city" in explainer.onehot_cols
+    assert set(explainer.onehot_dict["cat__city"]) == {
+        "cat__city_A",
+        "cat__city_B",
+        "cat__city_C",
+    }
+
+
+def test_pipeline_auto_detect_cats_does_not_group_drop_if_binary():
+    X = pd.DataFrame(
+        {
+            "age": [20, 21, 22, 23, 24, 25],
+            "city": ["A", "B", "A", "B", "B", "A"],
+        }
+    )
+    y = pd.Series([10, 11, 12, 13, 14, 15])
+
+    preprocessor = ColumnTransformer(
+        [
+            ("num", StandardScaler(), ["age"]),
+            (
+                "cat",
+                OneHotEncoder(
+                    handle_unknown="ignore", sparse_output=False, drop="if_binary"
+                ),
+                ["city"],
+            ),
+        ],
+        sparse_threshold=0,
+    )
+    pipeline = Pipeline(
+        [
+            ("preprocessor", preprocessor),
+            ("model", LinearRegression()),
+        ]
+    ).fit(X, y)
+
+    explainer = RegressionExplainer(
+        pipeline,
+        X,
+        y,
+        auto_detect_pipeline_cats=True,
+    )
+
+    assert "cat__city" not in explainer.onehot_cols


### PR DESCRIPTION
## Summary
- add pipeline feature naming options: `strip_pipeline_prefix` and `feature_name_fn`
- add `auto_detect_pipeline_cats` to infer grouped onehot categorical features from transformed pipeline output
- relax `parse_cats` validation to accept binary-like scaled onehot columns (not only strict `0/1`)
- preserve original index when building transformed pipeline dataframes
- improve pipeline extraction fallback warning with actionable guidance
- add focused unit tests for helper methods and extend pipeline integration tests
- document new pipeline options and behavior in README + docs + release notes
- update TODO with completed issue `#213` item

## Testing
- `.venv/bin/pytest -q tests/test_explainer_methods.py tests/test_pipelines.py`

## Issue
Refs #213
