### PR TITLE
Add LightGBM dtreeviz tree visualization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The library includes:
 - *Permutation importances* (how much does the model metric deteriorate when you shuffle a feature?)
 - *Partial dependence plots* (how does the model prediction change when you vary a single feature?
 - *Shap interaction values* (decompose the shap value into a direct effect an interaction effects)
-- For Random Forests and xgboost models: visualisation of individual decision trees
+- For Random Forest, XGBoost, and LightGBM models: visualisation of individual decision trees
 - Plus for classifiers: precision plots, confusion matrix, ROC AUC plot, PR AUC plot, etc
 - For regression models: goodness-of-fit plots, residual plots, etc.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 - Fix XGBoost multiclass decision-path summary wording to display `prediction (logodds)` when explainer `model_output='logodds'`.
 - Fix issue #256: add robust multiclass probability fallback for classifiers that expose `decision_function` but not `predict_proba` (e.g. `LinearSVC`), and use it consistently across kernel SHAP, prediction helpers, PDP, and permutation scorer paths.
 - Prevent multiclass class-count mismatches when user-provided/broken `predict_proba` outputs do not match model class count by falling back to `decision_function`-based probabilities.
+- Fix issue #118: add LightGBM decision-tree visualization support (dtreeviz) across explainer auto-detection, tree plotting, and decision-path rendering in dashboard tree tabs.
+- Fix dtreeviz callback rendering on macOS by switching matplotlib to a non-interactive backend for off-main-thread tree rendering to prevent dashboard 500 errors.
 
 ### Tests
 - Add regression tests for LightGBM with string categorical features covering dashboard initialization, `get_shap_row(...)`, unseen categorical values in `X_row`, and regression dashboard initialization.
@@ -22,6 +24,7 @@
 - Add explainer-method unit tests for binary-like onehot detection, transformed feature-name deduping, inferred pipeline cats, and pipeline extraction warning text.
 - Add regression tests for issue #256 covering multiclass `LinearSVC` with kernel SHAP, PDP, and permutation-importances flows using `decision_function` fallback.
 - Add guard tests to confirm multiclass `predict_proba` models (logistic regression) keep working for PDP and permutation-importances paths.
+- Add LightGBM tree-visualization regression tests (shadow trees, decision paths, plot_trees, and dtreeviz render contracts) in the boosting-model test suite.
 
 ### Improvements
 - Add pipeline feature-name cleanup options: `strip_pipeline_prefix=True` and `feature_name_fn=...` for sklearn/imblearn pipeline transformed output columns.

--- a/TODO.md
+++ b/TODO.md
@@ -12,22 +12,23 @@
 - [S][Hub][#146/#342] hub.to_yaml integrate_dashboard_yamls honors pickle_type and dumps integrated explainer artifacts.
 - [M][Explainers][#294] align/explain multiclass logodds between Contributions Plot and Prediction Box (+ PDP highlight and XGBoost decision path wording alignment).
 - [M][Explainers/Methods/Docs][#213] improve sklearn/imblearn pipeline support: feature-name cleanup (`strip_pipeline_prefix`, `feature_name_fn`), auto-detect onehot groups (`auto_detect_pipeline_cats`), accept binary-like scaled onehot columns in `cats`, preserve transformed index, add warnings/docs/tests.
+- [M][Explainers/Methods/Tests/Docs][#256] improve multiclass LinearSVC support/docs with decision_function probability fallback and regression coverage for SHAP/PDP/permutation flows.
+- [M][Explainers/Methods/Components/Tests][#118] add LightGBM tree visualization support (dtreeviz), including tree explainer wiring, dashboard tree tabs, and regression coverage.
 
 **Now**
-- [M][Explainers][#118] add LightGBM tree visualization support (dtreeviz).
+- [M][Dashboard][#161] more flexible instantiate_component (no explainer needed for non-ExplainerComponents).
 
 **Next**
-- [M][Dashboard][#263/#161] more flexible instantiate_component (no explainer needed for non-ExplainerComponents).
+- [M] add ExtraTrees and GradientBoostingClassifier to tree visualizers.
 
 **Backlog: Explainers**
 - [M] add plain language explanations for plots (in_words + UI toggle).
 - [S] pass n_jobs to pdp_isolate.
 - [M] add ExtraTrees and GradientBoostingClassifier to tree visualizers.
-- [M][#118] add LightGBM tree visualization support (dtreeviz).
 
 **Backlog: Dashboard**
 - [S] make poweredby right-aligned.
-- [M][#263/#161] more flexible instantiate_component (no explainer needed for non-ExplainerComponents).
+- [M][#161] more flexible instantiate_component (no explainer needed for non-ExplainerComponents).
 - [M] add TablePopout.
 - [M][#247] add EDA-style feature histograms/bar charts/correlation graphs.
 - [M/L] add cost calculator/optimizer for classifier models (confusion matrix weights, Youden J).
@@ -54,7 +55,6 @@
 - [M] support SamplingExplainer, PartitionExplainer, PermutationExplainer, AdditiveExplainer.
 - [M] support LimeTabularExplainer.
 - [M] investigate method from https://arxiv.org/abs/2006.04750.
-- [M][#256] improve multiclass LinearSVC support/docs (class-count mismatch with SHAP output).
 - [M][#229] clarify/add support path for Poisson and Gamma regression explainers.
 
 **Backlog: Plots**

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -126,7 +126,7 @@ And you need to tell heroku how to start your server in ``Procfile``::
 Graphviz buildpack
 ------------------
 
-If you want to visualize individual trees inside your ``RandomForest`` or ``xgboost``
+If you want to visualize individual trees inside your ``RandomForest``, ``xgboost`` or ``lightgbm``
 model using the ``dtreeviz`` package you will
 need to make sure that ``graphviz`` is installed on your ``heroku`` dyno by
 adding the following buildstack (as well as the ``python`` buildpack):

--- a/docs/source/explainers.rst
+++ b/docs/source/explainers.rst
@@ -456,10 +456,10 @@ plot_residuals_vs_feature
 DecisionTree Plots
 ------------------
 
-There are additional mixin classes specifically for ``sklearn`` ``RandomForests``
-and for xgboost models that define additional methods and plots to investigate and visualize
-individual decision trees within the ensemblke. These
-uses the ``dtreeviz`` library to visualize individual decision trees.
+There are additional mixin classes specifically for ``sklearn`` ``RandomForests``,
+``xgboost``, and ``lightgbm`` models that define additional methods and plots to
+investigate and visualize individual decision trees within the ensemble. These
+use the ``dtreeviz`` library to visualize individual decision trees.
 
 You can get a pd.DataFrame summary of the path that a specific index row took
 through a specific decision tree.
@@ -476,9 +476,9 @@ And for dtreeviz visualization of individual decision trees (svg format)::
     explainer.decisiontree_file(tree_idx, index)
     explainer.decisiontree_encoded(tree_idx, index)
 
-These methods are part of the ``RandomForestExplainer`` and XGBExplainer`` mixin
-classes that get automatically loaded when you pass either a RandomForest
-or XGBoost model.
+These methods are part of the ``RandomForestExplainer``, ``XGBExplainer``, and
+``LGBMExplainer`` mixin classes that get automatically loaded when you pass a
+RandomForest, XGBoost, or LightGBM model.
 
 
 plot_trees
@@ -661,12 +661,12 @@ restrict candidate rows by feature values before selecting a random index::
 .. automethod:: explainerdashboard.explainers.RegressionExplainer.random_index
 
 
-RandomForest and XGBoost outputs
---------------------------------
+RandomForest, XGBoost, and LightGBM outputs
+-------------------------------------------
 
-For RandomForest and XGBoost models mixin classes that visualize individual
-decision trees will be loaded: ``RandomForestExplainer`` and ``XGBExplainer``
-with the following additional methods::
+For RandomForest, XGBoost, and LightGBM models mixin classes that visualize
+individual decision trees will be loaded: ``RandomForestExplainer``,
+``XGBExplainer``, and ``LGBMExplainer`` with the following additional methods::
 
     decisiontree_df(tree_idx, index, pos_label=None)
     decisiontree_summary_df(tree_idx, index, round=2, pos_label=None)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,8 @@ with just two lines of code.
 
 It allows you to investigate SHAP values, permutation importances,
 interaction effects, partial dependence plots, all kinds of performance plots,
-and even individual decision trees inside a random forest. With ``explainerdashboard`` any data
+and even individual decision trees inside random forest, XGBoost, and LightGBM models.
+With ``explainerdashboard`` any data
 scientist can create an interactive explainable AI web app in minutes,
 without having to know anything about web development or deployment.
 

--- a/explainerdashboard/dashboard_components/decisiontree_components.py
+++ b/explainerdashboard/dashboard_components/decisiontree_components.py
@@ -8,7 +8,7 @@ from dash import html, dcc, Input, Output, State
 from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 
-from ..explainers import RandomForestExplainer, XGBExplainer
+from ..explainers import RandomForestExplainer, XGBExplainer, LGBMExplainer
 from ..dashboard_methods import *
 from .. import to_html
 
@@ -94,12 +94,20 @@ class DecisionTreesComponent(ExplainerComponent):
         elif isinstance(self.explainer, XGBExplainer):
             if self.description is None:
                 self.description = """
-            Shows the marginal contributions of each decision tree in an 
+            Shows the marginal contributions of each decision tree in an
             xgboost ensemble to the final prediction. This demonstrates that
             an xgboost model is simply a sum of individual decision trees.
             """
             if self.subtitle == "Displaying individual decision trees":
                 self.subtitle += " inside xgboost model"
+        elif isinstance(self.explainer, LGBMExplainer):
+            if self.description is None:
+                self.description = """
+            Shows the marginal contributions of each decision tree in a
+            LightGBM ensemble to the final prediction.
+            """
+            if self.subtitle == "Displaying individual decision trees":
+                self.subtitle += " inside LightGBM model"
         else:
             if self.description is None:
                 self.description = ""

--- a/explainerdashboard/explainer_plots.py
+++ b/explainerdashboard/explainer_plots.py
@@ -2930,6 +2930,7 @@ def plotly_xgboost_trees(
     target="",
     units="",
     higher_is_better=True,
+    model_name="xgboost",
 ):
     """Generate a plot showing the prediction of every single tree inside an XGBoost model
 
@@ -2944,6 +2945,8 @@ def plotly_xgboost_trees(
         units (str, optional): Units of target variable. Defaults to "".
         higher_is_better (bool, optional): up is green, down is red. If False then
             flip the colors.
+        model_name (str, optional): model family label used in chart titles.
+            Defaults to "xgboost".
 
     Returns:
         Plotly fig
@@ -3041,10 +3044,10 @@ def plotly_xgboost_trees(
     )
 
     if target:
-        title = f"Individual xgboost decision trees predicting {target}"
+        title = f"Individual {model_name} decision trees predicting {target}"
         yaxis_title = f"Predicted {target} {f'({units})' if units else ''}"
     else:
-        title = "Individual xgboost decision trees"
+        title = f"Individual {model_name} decision trees"
         yaxis_title = f"Predicted outcome ({units})" if units else "Predicted outcome"
 
     layout = go.Layout(

--- a/scripts/run_lgbm_dashboard.py
+++ b/scripts/run_lgbm_dashboard.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Launch a local ExplainerDashboard for a LightGBM classifier."""
+
+import os
+import argparse
+
+# DTreeViz renders legends with Matplotlib inside Dash callback threads.
+# On macOS the default GUI backend can crash outside the main thread.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import matplotlib
+from lightgbm import LGBMClassifier
+
+from explainerdashboard import ClassifierExplainer, ExplainerDashboard
+from explainerdashboard.datasets import titanic_survive, titanic_names
+
+matplotlib.use("Agg", force=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Train a LightGBM model and launch an ExplainerDashboard."
+    )
+    parser.add_argument("--port", type=int, default=8050, help="Dashboard port.")
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host interface to bind."
+    )
+    parser.add_argument(
+        "--n-estimators", type=int, default=50, help="Number of boosting rounds."
+    )
+    parser.add_argument("--max-depth", type=int, default=3, help="Max tree depth.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    X_train, y_train, X_test, y_test = titanic_survive()
+    test_names = titanic_names()[1]
+
+    model = LGBMClassifier(
+        n_estimators=args.n_estimators,
+        max_depth=args.max_depth,
+        random_state=42,
+        verbosity=-1,
+    )
+    model.fit(X_train, y_train)
+
+    explainer = ClassifierExplainer(
+        model,
+        X_test,
+        y_test,
+        idxs=test_names,
+        labels=["Not survived", "Survived"],
+        cats=[{"Gender": ["Sex_female", "Sex_male", "Sex_nan"]}, "Deck", "Embarked"],
+        cats_notencoded={"Gender": "No Gender"},
+    )
+
+    dashboard = ExplainerDashboard(
+        explainer,
+        title="LightGBM Explainer (TreeViz Demo)",
+        decision_trees=True,
+        shap_interaction=False,
+    )
+    dashboard.run(port=args.port, host=args.host)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_boosting_models.py
+++ b/tests/test_boosting_models.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import numpy as np
+import plotly.graph_objects as go
+import dtreeviz
 
 
 def test_xgbreg_preds(precalculated_xgb_regression_explainer):
@@ -232,6 +234,76 @@ def test_lgbmclas_prediction_result_df(precalculated_lgbm_classifier_explainer):
     assert isinstance(
         precalculated_lgbm_classifier_explainer.prediction_result_df(0), pd.DataFrame
     )
+
+
+def test_lgbmclas_treeviz_graphviz_available(precalculated_lgbm_classifier_explainer):
+    assert isinstance(precalculated_lgbm_classifier_explainer.graphviz_available, bool)
+
+
+def test_lgbmclas_treeviz_shadow_trees(precalculated_lgbm_classifier_explainer):
+    dt = precalculated_lgbm_classifier_explainer.shadow_trees
+    assert isinstance(dt, list)
+    assert isinstance(dt[0], dtreeviz.models.shadow_decision_tree.ShadowDecTree)
+
+
+def test_lgbmclas_treeviz_decisionpath_df(precalculated_lgbm_classifier_explainer):
+    df = precalculated_lgbm_classifier_explainer.get_decisionpath_df(
+        tree_idx=0, index=0
+    )
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_lgbmclas_treeviz_decisiontree_view_contract(
+    precalculated_lgbm_classifier_explainer,
+):
+    precalculated_lgbm_classifier_explainer._graphviz_available = True
+    render = precalculated_lgbm_classifier_explainer.decisiontree_view(
+        tree_idx=0, index=0
+    )
+    assert isinstance(render, dtreeviz.utils.DTreeVizRender)
+
+
+def test_lgbmclas_treeviz_plot_trees(precalculated_lgbm_classifier_explainer):
+    fig = precalculated_lgbm_classifier_explainer.plot_trees(index=0)
+    assert isinstance(fig, go.Figure)
+
+    fig = precalculated_lgbm_classifier_explainer.plot_trees(index=0, highlight_tree=0)
+    assert isinstance(fig, go.Figure)
+
+
+def test_lgbmreg_treeviz_shadow_trees(precalculated_lgbm_regression_explainer):
+    dt = precalculated_lgbm_regression_explainer.shadow_trees
+    assert isinstance(dt, list)
+    assert isinstance(dt[0], dtreeviz.models.shadow_decision_tree.ShadowDecTree)
+
+
+def test_lgbmreg_treeviz_decisionpath_df(
+    precalculated_lgbm_regression_explainer, test_names
+):
+    df = precalculated_lgbm_regression_explainer.get_decisionpath_df(
+        tree_idx=0, index=0
+    )
+    assert isinstance(df, pd.DataFrame)
+
+    df = precalculated_lgbm_regression_explainer.get_decisionpath_df(
+        tree_idx=0, index=test_names[0]
+    )
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_lgbmreg_treeviz_plot_trees(
+    precalculated_lgbm_regression_explainer, test_names
+):
+    fig = precalculated_lgbm_regression_explainer.plot_trees(index=0)
+    assert isinstance(fig, go.Figure)
+
+    fig = precalculated_lgbm_regression_explainer.plot_trees(index=test_names[0])
+    assert isinstance(fig, go.Figure)
+
+    fig = precalculated_lgbm_regression_explainer.plot_trees(
+        index=test_names[0], highlight_tree=0
+    )
+    assert isinstance(fig, go.Figure)
 
 
 def test_xgbclas_preds(precalculated_xgb_classifier_explainer):


### PR DESCRIPTION
## Summary
- add LightGBM tree explainer support (`LGBMExplainer`) with dtreeviz shadow trees, decision-path rendering, and per-tree contribution plots
- wire LightGBM into explainer auto-detection and decision-tree dashboard components
- add a safe threaded dtreeviz backend fallback (`matplotlib` -> `Agg`) to prevent macOS callback crashes
- add/merge LightGBM treeviz regression tests into `tests/test_boosting_models.py`
- add a local demo launcher at `scripts/run_lgbm_dashboard.py`
- update `README.md`, `docs/source/explainers.rst`, `docs/source/deployment.rst`, and `docs/source/index.rst` to document LightGBM tree support
- update `TODO.md` and `RELEASE_NOTES.md`

## Validation
- `uv run pytest -q tests/test_boosting_models.py -k lgbm`
- `uv run pytest -q tests/test_xgboost_treeviz.py`

Closes #118
